### PR TITLE
Use immutable object (an empty tuple, not an empty list) as the default

### DIFF
--- a/geoscript/render/map.py
+++ b/geoscript/render/map.py
@@ -11,7 +11,7 @@ _renderers = {
 
 class Map:
 
-   def __init__(self, layers, styles=[], title=None):
+   def __init__(self, layers, styles=(), title=None):
      self.layers = layers if isinstance(layers, list) else [layers]
      self.styles = styles if isinstance(styles, list) else [styles]
 


### PR DESCRIPTION
I was looking over the GeoScript-PY code and noticed this gotcha in the default parameters for Map's constructor.  http://stackoverflow.com/questions/1132941/least-astonishment-in-python-the-mutable-default-argument describes the issue in case you're not familiar with it.
