### PR TITLE
Fix issue #16, add background color option to renderers

### DIFF
--- a/geoscript/render/base.py
+++ b/geoscript/render/base.py
@@ -28,7 +28,7 @@ class RendererBase:
 
       img = image.BufferedImage(w, h, image.BufferedImage.TYPE_INT_ARGB)
       g = img.getGraphics()
-      g.setColor(awt.Color.white)
+      g.setColor(style.Color(options["bgcolor"]).expr.value if options.has_key("bgcolor") else awt.Color.white)
       g.fillRect(0, 0, w, h)
       
       renderer.paint(g, awt.Rectangle(w,h), bounds)


### PR DESCRIPTION
from geoscript.style import *
from geoscript.render import *
from geoscript.geom import *

style = Stroke('black', width=2) + Fill('#ff0000', opacity=0.75)
draw(Point(0,0).buffer(1), style, bgcolor="blue")
