### PR TITLE
Fix issue #5, allow for specifying size in Icon

### DIFF
--- a/geoscript/style/icon.py
+++ b/geoscript/style/icon.py
@@ -2,6 +2,7 @@ import mimetypes
 from geoscript.util import toURL
 from geoscript.style import util
 from geoscript.style.symbolizer import Symbolizer
+from geoscript.style.expression import Expression
 from org.geotools.styling import PointSymbolizer, PolygonSymbolizer
 
 class Icon(Symbolizer):
@@ -14,14 +15,15 @@ class Icon(Symbolizer):
   >>> icon = Icon('tests/work/colorblocks.png', 'image/png')
   >>> icon = Icon('http://v2.suite.opengeo.org/geoserver/styles/smileyface.png', 'image/png')
   """
-  def __init__(self, url, format=None):
+  def __init__(self, url, format=None, size=None):
     Symbolizer.__init__(self)
     self.url = toURL(url)
 
     if not format:
       format = mimetypes.guess_type(url)[0]
-    
+
     self.format = format
+    self.size = Expression(size) if size else None
 
   def _prepare(self, rule):
     syms = util.symbolizers(rule, PointSymbolizer)
@@ -32,6 +34,8 @@ class Icon(Symbolizer):
     Symbolizer._apply(self, sym)
     eg = self.factory.createExternalGraphic(self.url, self.format)
     g = util.graphic(sym)
+    if self.size:
+        g.size = self.size.expr
     g.setMarks([])
     if g:
       g.graphicalSymbols().add(eg)


### PR DESCRIPTION
Support the size modifier for icon.  Especially important for SVG icons.

from geoscript.style import *
from geoscript.render import *
from geoscript.geom import *

geom = Point(10,10)
draw(geom, Icon('smileyface.png', size=12))
