### PR TITLE
Remove spatialite dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,17 +69,17 @@
       <artifactId>gt-jdbc-mysql</artifactId>
       <version>${gt.version}</version>
     </dependency>
-    <dependency>
+    <!--dependency>
       <groupId>org.geotools.jdbc</groupId>
       <artifactId>gt-jdbc-spatialite</artifactId>
       <version>${gt.version}</version>
-      <!--exclusions>
+      <exclusions>
         <exclusion>
           <groupId>org.xerial</groupId>
           <artifactId>sqlite-jdbc-spatialite</artifactId>
         </exclusion>
-      </exclusions-->
-    </dependency>
+      </exclusions>
+    </dependency-->
     <dependency>
       <groupId>org.geotools.jdbc</groupId>
       <artifactId>gt-jdbc-teradata</artifactId>


### PR DESCRIPTION
Not sure if this is the right fix, but I'm trying to get rid of messages like the following when running GeoServer with the scripting branch:

```
java.lang.UnsatisfiedLinkError: /private/var/folders/iD/iD7PC9TmH6eHB0oTYSVJzE+++TI/-Tmp-/sqlite-3.7.2-libsqlitejdbc.jnilib:  Library not loaded: /Users/opengeo/buildroot//geos/lib/libgeos_c.1.dylib   Referenced from: /private/var/folders/iD/iD7PC9TmH6eHB0oTYSVJzE+++TI/-Tmp-/sqlite-3.7.2-libsqlitejdbc.jnilib   Reason: image not found
```

Didn't verify that tests still pass with this change.
