### PR TITLE
Add opacity, rotation, stroke properties.  Add the ability to have no fi...

### DIFF
--- a/geoscript/style/shape.py
+++ b/geoscript/style/shape.py
@@ -20,11 +20,18 @@ class Shape(Symbolizer):
   "star", "cross", and "x".
   """
 
-  def __init__(self, color=None, size=6, type='circle'):
+  def __init__(self, color=None, size=6, type='circle', opacity=1.0, rotation=0):
     Symbolizer.__init__(self)
     self.color = Color(color) if color else None
     self.size = Expression(size)
     self.type = type
+    self.opacity = Expression(opacity)
+    self.rotation = Expression(rotation)
+    self._stroke = None
+
+  def stroke(self, color="#000000", width=1, dash=None, cap=None, join=None):
+    self._stroke = Stroke(color, width, dash, cap, join)
+    return self
 
   def _prepare(self, rule):
     syms = util.symbolizers(rule, PointSymbolizer)
@@ -35,15 +42,22 @@ class Shape(Symbolizer):
     Symbolizer._apply(self, sym)
     g = util.graphic(sym)
     g.setSize(self.size.expr)
+    if self.rotation != None and self.rotation.expr != None:
+        g.setRotation(self.rotation.expr)
     g.graphicalSymbols().clear()
     g.graphicalSymbols().add(self._mark())
 
   def _mark(self):
     f = self.factory
     mark = f.createMark()
-
-    mark.setStroke(Stroke(self.color)._stroke())
-    mark.setFill(Fill(self.color)._fill())
+    if self._stroke != None:
+        mark.setStroke(self._stroke._stroke())
+    else:
+        mark.setStroke(Stroke(self.color)._stroke())
+    if self.color != None and self.color.expr != None:
+        mark.setFill(Fill(self.color, self.opacity)._fill())
+    else:
+        mark.setFill(None)
     mark.setWellKnownName(self.type)
 
     return mark


### PR DESCRIPTION
...ll.

Solves issue #10.  Here is some example code:

from geoscript.style import *
from geoscript.render import *
from geoscript.geom import *

geom = Point(10,10)
draw(geom, Shape(None, type="triangle", size=12, opacity=0.5, rotation=45).stroke("black"))
