### PR TITLE
Add curved geometry types

### DIFF
--- a/geoscript/geom/__init__.py
+++ b/geoscript/geom/__init__.py
@@ -5,6 +5,10 @@ from polygon import Polygon
 from multipoint import MultiPoint
 from multilinestring import MultiLineString
 from multipolygon import MultiPolygon
+from circularstring import CircularString
+from circularring import CircularRing
+from compoundcurve import CompoundCurve
+from compoundring import CompoundRing
 from bounds import Bounds
 from geom import Geometry
 from geom import prepare, simplify, transform, buffer, delaunay, voronoi
@@ -22,3 +26,7 @@ core.register(MultiPoint)
 core.register(MultiLineString)
 core.register(MultiPolygon)
 core.register(Bounds)
+core.register(CircularString)
+core.register(CircularRing)
+core.register(CompoundCurve)
+core.register(CompoundRing)

--- a/geoscript/geom/circularring.py
+++ b/geoscript/geom/circularring.py
@@ -1,0 +1,39 @@
+from com.vividsolutions.jts.geom import Coordinate
+from org.geotools.geometry.jts import CircularRing as _CircularRing
+from org.geotools.geometry.jts import CurvedGeometryFactory
+from java.lang import Double
+from geoscript import core
+import geom
+
+class CircularRing(_CircularRing):
+    """
+    A CircularRing geometry.
+
+    *coords* is a variable list of ``list``/``tuple`` arguments.
+
+    >>> CircularRing([1,1], [5,5], [2,2], [4,5], [1,1])
+    CIRCULARSTRING(1.0 1.0, 5.0 5.0, 2.0 2.0, 4.0 5.0, 1.0 1.0)
+    """
+
+    def __init__(self, *coords):
+        tolerance = Double.MAX_VALUE    
+        if len(coords) == 1 and isinstance(coords[0], _CircularRing):
+          cs = coords[0].coordinateSequence
+        else:
+          l = []
+          for c in coords:
+            l.append( Coordinate(c[0],c[1]) )
+            if len(c) > 2:
+              l[-1].z = c[2]
+          cs = geom._factory.coordinateSequenceFactory.create(l)
+        
+        doubles = []
+        for c in cs.toCoordinateArray():
+            doubles.append(c.x)
+            doubles.append(c.y)
+
+        cgf = CurvedGeometryFactory(tolerance)
+        _CircularRing.__init__(self, doubles, cgf, tolerance)
+
+geom._enhance(CircularRing)
+core.registerTypeMapping(_CircularRing, CircularRing)

--- a/geoscript/geom/circularstring.py
+++ b/geoscript/geom/circularstring.py
@@ -1,0 +1,39 @@
+from com.vividsolutions.jts.geom import Coordinate
+from org.geotools.geometry.jts import CircularString as _CircularString
+from org.geotools.geometry.jts import CurvedGeometryFactory
+from java.lang import Double
+from geoscript import core
+import geom
+
+class CircularString(_CircularString):
+    """
+    A CircularString geometry.
+
+    *coords* is a variable list of ``list``/``tuple`` arguments.
+
+    >>> CircularString([1,1], [5,5], [2,2])
+    CIRCULARSTRING(1.0 1.0, 5.0 5.0, 2.0 2.0)
+    """
+
+    def __init__(self, *coords):
+        tolerance = Double.MAX_VALUE    
+        if len(coords) == 1 and isinstance(coords[0], _CircularString):
+          cs = coords[0].coordinateSequence
+        else:
+          l = []
+          for c in coords:
+            l.append( Coordinate(c[0],c[1]) )
+            if len(c) > 2:
+              l[-1].z = c[2]
+          cs = geom._factory.coordinateSequenceFactory.create(l)
+        
+        doubles = []
+        for c in cs.toCoordinateArray():
+            doubles.append(c.x)
+            doubles.append(c.y)
+
+        cgf = CurvedGeometryFactory(tolerance)
+        _CircularString.__init__(self, doubles, cgf, tolerance)
+
+geom._enhance(CircularString)
+core.registerTypeMapping(_CircularString, CircularString)

--- a/geoscript/geom/compoundcurve.py
+++ b/geoscript/geom/compoundcurve.py
@@ -1,0 +1,31 @@
+from com.vividsolutions.jts.geom import Coordinate
+from org.geotools.geometry.jts import CompoundCurve as _CompoundCurve
+from org.geotools.geometry.jts import CurvedGeometryFactory
+from linestring import LineString
+from circularstring import CircularString
+from java.lang import Double
+from geoscript import core
+import geom
+
+class CompoundCurve(_CompoundCurve):
+    """
+    A CompoundCurve geometry.
+
+    *linestrings* is a variable list of ``LineStrings`` or ``CircularStrings`` arguments.
+
+    >>> CompoundCurve(CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]), LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]))
+    COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))
+    """
+
+    def __init__(self, *linestrings):
+        tolerance = Double.MAX_VALUE    
+        if len(linestrings) == 1 and isinstance(linestrings[0], _CompoundCurve):
+            cc = linestrings[0]
+            linestrings = cc.components
+
+        cgf = CurvedGeometryFactory(tolerance)
+        _CompoundCurve.__init__(self, linestrings, cgf, tolerance)
+
+geom._enhance(CompoundCurve)
+core.registerTypeMapping(_CompoundCurve, CompoundCurve)
+

--- a/geoscript/geom/compoundring.py
+++ b/geoscript/geom/compoundring.py
@@ -1,0 +1,32 @@
+from com.vividsolutions.jts.geom import Coordinate
+from org.geotools.geometry.jts import CompoundRing as _CompoundRing
+from org.geotools.geometry.jts import CurvedGeometryFactory
+from linestring import LineString
+from circularstring import CircularString
+from java.lang import Double
+from geoscript import core
+import geom
+
+class CompoundRing(_CompoundRing):
+    """
+    A CompoundRing geometry.
+
+    *linestrings* is a variable list of ``LineStrings`` or ``CircularStrings`` arguments.
+
+    >>> CompoundRing(CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]),LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [10.0, 10.0]))
+    COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 10.0 10.0))
+    """
+
+    def __init__(self, *linestrings):
+        tolerance = Double.MAX_VALUE    
+        if len(linestrings) == 1 and isinstance(linestrings[0], _CompoundRing):
+            cc = linestrings[0]
+            linestrings = cc.components
+
+        cgf = CurvedGeometryFactory(tolerance)
+        _CompoundRing.__init__(self, linestrings, cgf, tolerance)
+
+geom._enhance(CompoundRing)
+core.registerTypeMapping(_CompoundRing, CompoundRing)
+
+

--- a/geoscript/geom/io/wkt.py
+++ b/geoscript/geom/io/wkt.py
@@ -1,4 +1,5 @@
-from com.vividsolutions.jts.io import WKTReader, WKTWriter 
+from com.vividsolutions.jts.io import WKTWriter
+from org.geotools.geometry.jts import WKTReader2 as WKTReader
 from geoscript.util import deprecated
 
 def readWKT(wkt):

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -56,6 +56,28 @@ class GeomTest(unittest.TestCase):
     mp = geom.MultiPolygon([ [[1,2],[3,4],[5,6],[1,2]] ])
     self.assertEqual('MULTIPOLYGON (((1 2, 3 4, 5 6, 1 2)))', str(mp))
 
+  def testCircularString(self):
+    cs = geom.CircularString([6.12, 10.0],[7.07, 7.07],[10.0, 0.0])
+    self.assertEqual('CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)', str(cs))
+  
+  def testCircularRing(self):
+    cr = geom.CircularRing( [2.0, 1.0], [1.0, 2.0], [0.0, 1.0], [1.0, 0.0], [2.0, 1.0])
+    self.assertEqual('CIRCULARSTRING(2.0 1.0, 1.0 2.0, 0.0 1.0, 1.0 0.0, 2.0 1.0)', str(cr))
+
+  def testCompoundCurve(self):
+    cc = geom.CompoundCurve(
+        geom.CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]),
+        geom.LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0])
+    )
+    self.assertEqual('COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))', str(cc))
+
+  def testCompoundRing(self):
+    cc = geom.CompoundRing(
+        geom.CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]),
+        geom.LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [10.0, 10.0])
+    )
+    self.assertEqual('COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 10.0 10.0))', str(cc))
+
   def testBounds(self):
     b = geom.Bounds(1.0, 2.0, 3.0, 4.0)
     self.assertEqual('(1.0, 2.0, 3.0, 4.0)', str(b))
@@ -107,6 +129,10 @@ class GeomTest(unittest.TestCase):
     self.assertEqual('Point',g.geometryType)
     self.assertEqual(1,g.x)
     self.assertEqual(2,g.y)
+
+  def testReadCurvedWKT(self):
+    g = geom.readWKT('CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)')
+    self.assertEqual('CircularString', g.geometryType)
 
   def testReadWKB(self):
     p = geom.Point(1,2)


### PR DESCRIPTION
I would like to add the curved geometry types recently added to GeoTools 12.  Since geoscript-py contains the linear ring geometry type, I included circular ring and compound ring.  I can remove them from the pull request if they are un wanted.

Thanks!
Jared
