### PR TITLE
Update ant version for antrun to match other Geo* projects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,14 +232,20 @@
        <artifactId>maven-antrun-plugin</artifactId>
        <dependencies>
           <dependency>
-            <groupId>ant</groupId>
+            <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.6.5</version>
+            <version>1.8.4</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>
             <artifactId>ant-contrib</artifactId>
             <version>1.0b3</version>
+            <exclusions>
+              <exclusion>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Was running into build failures due to the out of date version of ant.  1.8.4 is also old, but it's the version GeoServer uses and it fixes the build problem.