### PR TITLE
Updates Geoscript-py to use latest Geotools

### DIFF
--- a/geoscript/__init__.py
+++ b/geoscript/__init__.py
@@ -3,7 +3,7 @@ from java.lang import System
 
 try:
    import org.geotools
-   from org.geotools.factory import Hints
+   from org.geotools.util.factory import Hints
 
    # by default the geotools referenceing Systemtem assumes yx or lat/lon 
    if not System.getProperty("org.geotools.referencing.forceXY"):

--- a/geoscript/filter.py
+++ b/geoscript/filter.py
@@ -7,7 +7,7 @@ from java import io, lang
 from org.opengis.filter import Filter as _Filter
 from org.geotools.filter.text.cql2 import CQL
 from org.geotools.filter.text.ecql import ECQL
-from org.geotools.xml import Parser, Encoder
+from org.geotools.xsd import Parser, Encoder
 from org.geotools.factory import CommonFactoryFinder
 from geoscript import core
 

--- a/geoscript/function.py
+++ b/geoscript/function.py
@@ -7,8 +7,8 @@ used in styles or for custom filter processing.
 import java
 import weakref
 import inspect
-from org.geotools.factory import FactoryIteratorProvider, CommonFactoryFinder
-from org.geotools.factory import GeoTools
+from org.geotools.factory import CommonFactoryFinder
+from org.geotools.util.factory import FactoryIteratorProvider, GeoTools
 from org.geotools.filter import FunctionFactory, FunctionExpressionImpl
 
 _factory = CommonFactoryFinder.getFilterFactory(None)

--- a/geoscript/geom/circularring.py
+++ b/geoscript/geom/circularring.py
@@ -12,7 +12,7 @@ class CircularRing(_CircularRing):
     *coords* is a variable list of ``list``/``tuple`` arguments.
 
     >>> CircularRing([1,1], [5,5], [2,2], [4,5], [1,1])
-    CIRCULARSTRING(1.0 1.0, 5.0 5.0, 2.0 2.0, 4.0 5.0, 1.0 1.0)
+    CIRCULARSTRING (1.0 1.0, 5.0 5.0, 2.0 2.0, 4.0 5.0, 1.0 1.0)
     """
 
     def __init__(self, *coords):

--- a/geoscript/geom/circularring.py
+++ b/geoscript/geom/circularring.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import Coordinate
+from org.locationtech.jts.geom import Coordinate
 from org.geotools.geometry.jts import CircularRing as _CircularRing
 from org.geotools.geometry.jts import CurvedGeometryFactory
 from java.lang import Double

--- a/geoscript/geom/circularstring.py
+++ b/geoscript/geom/circularstring.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import Coordinate
+from org.locationtech.jts.geom import Coordinate
 from org.geotools.geometry.jts import CircularString as _CircularString
 from org.geotools.geometry.jts import CurvedGeometryFactory
 from java.lang import Double

--- a/geoscript/geom/circularstring.py
+++ b/geoscript/geom/circularstring.py
@@ -12,7 +12,7 @@ class CircularString(_CircularString):
     *coords* is a variable list of ``list``/``tuple`` arguments.
 
     >>> CircularString([1,1], [5,5], [2,2])
-    CIRCULARSTRING(1.0 1.0, 5.0 5.0, 2.0 2.0)
+    CIRCULARSTRING (1.0 1.0, 5.0 5.0, 2.0 2.0)
     """
 
     def __init__(self, *coords):

--- a/geoscript/geom/compoundcurve.py
+++ b/geoscript/geom/compoundcurve.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import Coordinate
+from org.locationtech.jts.geom import Coordinate
 from org.geotools.geometry.jts import CompoundCurve as _CompoundCurve
 from org.geotools.geometry.jts import CurvedGeometryFactory
 from linestring import LineString

--- a/geoscript/geom/compoundcurve.py
+++ b/geoscript/geom/compoundcurve.py
@@ -14,7 +14,7 @@ class CompoundCurve(_CompoundCurve):
     *linestrings* is a variable list of ``LineStrings`` or ``CircularStrings`` arguments.
 
     >>> CompoundCurve(CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]), LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]))
-    COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))
+    COMPOUNDCURVE (CIRCULARSTRING (10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))
     """
 
     def __init__(self, *linestrings):

--- a/geoscript/geom/compoundring.py
+++ b/geoscript/geom/compoundring.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import Coordinate
+from org.locationtech.jts.geom import Coordinate
 from org.geotools.geometry.jts import CompoundRing as _CompoundRing
 from org.geotools.geometry.jts import CurvedGeometryFactory
 from linestring import LineString

--- a/geoscript/geom/compoundring.py
+++ b/geoscript/geom/compoundring.py
@@ -14,7 +14,7 @@ class CompoundRing(_CompoundRing):
     *linestrings* is a variable list of ``LineStrings`` or ``CircularStrings`` arguments.
 
     >>> CompoundRing(CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]),LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [10.0, 10.0]))
-    COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 10.0 10.0))
+    COMPOUNDCURVE (CIRCULARSTRING (10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 10.0 10.0))
     """
 
     def __init__(self, *linestrings):

--- a/geoscript/geom/geom.py
+++ b/geoscript/geom/geom.py
@@ -3,15 +3,15 @@ The :mod:`geom` module provides geometry classes and utilities for the construct
 """
 
 from java.awt.geom import AffineTransform
-from com.vividsolutions.jts.geom import GeometryFactory, CoordinateFilter
-from com.vividsolutions.jts.geom import Geometry as _Geometry
-from com.vividsolutions.jts.geom.prep import PreparedGeometryFactory
-from com.vividsolutions.jts.simplify import DouglasPeuckerSimplifier as DP
-from com.vividsolutions.jts.simplify import TopologyPreservingSimplifier as TP
-from com.vividsolutions.jts.densify import Densifier
-from com.vividsolutions.jts.triangulate import DelaunayTriangulationBuilder
-from com.vividsolutions.jts.triangulate import VoronoiDiagramBuilder
-from com.vividsolutions.jts.operation.buffer import BufferOp, BufferParameters
+from org.locationtech.jts.geom import GeometryFactory, CoordinateFilter
+from org.locationtech.jts.geom import Geometry as _Geometry
+from org.locationtech.jts.geom.prep import PreparedGeometryFactory
+from org.locationtech.jts.simplify import DouglasPeuckerSimplifier as DP
+from org.locationtech.jts.simplify import TopologyPreservingSimplifier as TP
+from org.locationtech.jts.densify import Densifier
+from org.locationtech.jts.triangulate import DelaunayTriangulationBuilder
+from org.locationtech.jts.triangulate import VoronoiDiagramBuilder
+from org.locationtech.jts.operation.buffer import BufferOp, BufferParameters
 from org.geotools.geometry.jts import JTS
 from org.geotools.referencing.operation.transform import AffineTransform2D
 from geoscript.geom.bounds import Bounds

--- a/geoscript/geom/io/gml.py
+++ b/geoscript/geom/io/gml.py
@@ -13,7 +13,7 @@ def writeGML(g, ver=2, format=True, xmldecl=False):
 
   >>> from geoscript.geom import Point 
   >>> writeGML(Point(1,2), format=False)
-  u'<gml:Point xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml"><gml:coord><gml:X>1.0</gml:X><gml:Y>2.0</gml:Y></gml:coord></gml:Point>'
+  u'<gml:Point xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink"><gml:coord><gml:X>1.0</gml:X><gml:Y>2.0</gml:Y></gml:coord></gml:Point>'
   """
   el = g.getGeometryType()
   

--- a/geoscript/geom/io/kml.py
+++ b/geoscript/geom/io/kml.py
@@ -1,5 +1,5 @@
 from geoscript.util import xml
-from com.vividsolutions.jts.geom import GeometryCollection
+from org.locationtech.jts.geom import GeometryCollection
 
 def writeKML(g, format=True, xmldecl=False, namespaces=True):
   """

--- a/geoscript/geom/io/wkb.py
+++ b/geoscript/geom/io/wkb.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.io import WKBReader, WKBWriter
+from org.locationtech.jts.io import WKBReader, WKBWriter
 from geoscript.util import bytes, deprecated
 
 def readWKB(wkb, base=16):

--- a/geoscript/geom/io/wkt.py
+++ b/geoscript/geom/io/wkt.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.io import WKTWriter
+from org.locationtech.jts.io import WKTWriter
 from org.geotools.geometry.jts import WKTReader2 as WKTReader
 from geoscript.util import deprecated
 

--- a/geoscript/geom/linearring.py
+++ b/geoscript/geom/linearring.py
@@ -1,5 +1,5 @@
-from com.vividsolutions.jts.geom import Coordinate
-from com.vividsolutions.jts.geom import LinearRing as _LinearRing
+from org.locationtech.jts.geom import Coordinate
+from org.locationtech.jts.geom import LinearRing as _LinearRing
 from linestring import LineString
 from geoscript import core
 import geom

--- a/geoscript/geom/linestring.py
+++ b/geoscript/geom/linestring.py
@@ -1,6 +1,6 @@
-from com.vividsolutions.jts.geom import Coordinate
-from com.vividsolutions.jts.geom import LineString as _LineString
-from com.vividsolutions.jts.linearref import LengthIndexedLine
+from org.locationtech.jts.geom import Coordinate
+from org.locationtech.jts.geom import LineString as _LineString
+from org.locationtech.jts.linearref import LengthIndexedLine
 from geoscript import core
 from geoscript.geom import Point
 import geom

--- a/geoscript/geom/multilinestring.py
+++ b/geoscript/geom/multilinestring.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import MultiLineString as _MultiLineString
+from org.locationtech.jts.geom import MultiLineString as _MultiLineString
 from linestring import LineString
 from geoscript import core
 import geom

--- a/geoscript/geom/multipoint.py
+++ b/geoscript/geom/multipoint.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import MultiPoint as _MultiPoint
+from org.locationtech.jts.geom import MultiPoint as _MultiPoint
 from geoscript import core
 from point import Point
 import geom

--- a/geoscript/geom/multipolygon.py
+++ b/geoscript/geom/multipolygon.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import MultiPolygon as _MultiPolygon
+from org.locationtech.jts.geom import MultiPolygon as _MultiPolygon
 from geoscript import core
 from polygon import Polygon
 import geom

--- a/geoscript/geom/point.py
+++ b/geoscript/geom/point.py
@@ -1,5 +1,5 @@
-from com.vividsolutions.jts.geom import Coordinate
-from com.vividsolutions.jts.geom import Point as _Point
+from org.locationtech.jts.geom import Coordinate
+from org.locationtech.jts.geom import Point as _Point
 from geoscript import core
 import geom
 

--- a/geoscript/geom/polygon.py
+++ b/geoscript/geom/polygon.py
@@ -1,4 +1,4 @@
-from com.vividsolutions.jts.geom import Polygon as _Polygon
+from org.locationtech.jts.geom import Polygon as _Polygon
 from geoscript import core
 from linearring import LinearRing
 import geom

--- a/geoscript/layer/layer.py
+++ b/geoscript/layer/layer.py
@@ -12,7 +12,8 @@ from geoscript.util.data import readFeatures
 from org.geoscript.util import CollectionDelegatingFeatureSource
 from org.geotools.data import FeatureSource, FeatureStore
 from org.geotools.data import DefaultQuery, Query, Transaction
-from org.geotools.factory import CommonFactoryFinder, Hints
+from org.geotools.factory import CommonFactoryFinder
+from org.geotools.util.factory import Hints
 from org.geotools.feature import FeatureCollection, FeatureCollections
 from org.opengis.filter.sort import SortOrder
 
@@ -542,7 +543,7 @@ class Layer(object):
     try:
       from net.opengis.wfs import WfsFactory
       from org.geotools.wfs.v1_1 import WFS, WFSConfiguration
-      from org.geotools.xml import Encoder
+      from org.geotools.xsd import Encoder
     except ImportError:
       raise Exception('toGML() not available, GML libraries not on classpath.') 
 

--- a/geoscript/layer/raster.py
+++ b/geoscript/layer/raster.py
@@ -9,7 +9,7 @@ from geoscript.feature import Feature
 from geoscript.layer.band import Band
 from org.opengis.parameter import GeneralParameterValue
 from org.opengis.referencing.datum import PixelInCell
-from org.geotools.factory import Hints
+from org.geotools.util.factory import Hints
 from org.geotools.geometry import DirectPosition2D
 from org.geotools.parameter import Parameter
 from org.geotools.coverage import CoverageFactoryFinder, GridSampleDimension

--- a/geoscript/style/io/sld.py
+++ b/geoscript/style/io/sld.py
@@ -1,6 +1,6 @@
 import sys
 from geoscript import util
-from org.geotools.styling import SLDTransformer
+from org.geotools.xml.styling import SLDTransformer
 
 def writeSLD(style, out=sys.stdout, format=True):
   tx = SLDTransformer()

--- a/geoscript/util/xml.py
+++ b/geoscript/util/xml.py
@@ -1,11 +1,11 @@
 import sys
 from javax.xml.namespace import QName
 from util import doInput, doOutput
-from org.geotools.xml import Parser, Encoder, Configuration
+from org.geotools.xsd import Parser, Encoder, Configuration
 from org.geotools.gml2 import GMLConfiguration as GML2
 from org.geotools.gml3 import GMLConfiguration as GML3
 from org.geotools.gml3.v3_2 import GMLConfiguration as GML32
-from org.geotools.wfs.v1_0 import WFSConfiguration as WFS10
+from org.geotools.wfs.v1_0 import WFSConfiguration_1_0 as WFS10
 from org.geotools.wfs.v1_1 import WFSConfiguration as WFS11
 from org.geotools.wfs.v2_0 import WFSConfiguration as WFS20
 from org.geotools.kml import KMLConfiguration as KML

--- a/geoscript/workspace/workspace.py
+++ b/geoscript/workspace/workspace.py
@@ -48,7 +48,7 @@ class Workspace:
     >>> l1 = ws.create('foo')
     >>> l2 = ws.create('bar')
     >>> ws.layers()
-    ['foo', 'bar']
+    ['bar', 'foo']
     """
 
     return [str(tn) for tn in self._store.typeNames]
@@ -99,7 +99,7 @@ class Workspace:
      >>> from geoscript.feature import Schema
      >>> l2 = ws.create(schema=Schema('bar', [('geom', geom.Point)]))
      >>> ws.layers()
-     ['foo', 'bar']
+     ['bar', 'foo']
      """
  
      if not name:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.geoscript</groupId>
   <artifactId>geoscript-py</artifactId>
   <packaging>jar</packaging>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.5-SNAPSHOT</version>
   <name>GeoScript Python</name>
 
   <repositories>
@@ -230,24 +230,7 @@
       </plugin>
       <plugin>
        <artifactId>maven-antrun-plugin</artifactId>
-       <dependencies>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.8.4</version>
-          </dependency>
-          <dependency>
-            <groupId>ant-contrib</groupId>
-            <artifactId>ant-contrib</artifactId>
-            <version>1.0b3</version>
-            <exclusions>
-              <exclusion>
-                <groupId>ant</groupId>
-                <artifactId>ant</artifactId>
-              </exclusion>
-            </exclusions>
-          </dependency>
-        </dependencies>
+       <version>1.8</version>
         <executions>
           <execution>
             <id>initialize</id>
@@ -262,7 +245,7 @@
             </goals>
           </execution>
           <execution>
-            <id>package</id>
+            <id>package-jars</id>
             <phase>package</phase>
             <configuration>
               <tasks>
@@ -328,7 +311,7 @@
   </profiles>
 
   <properties>
-    <gt.version>13-SNAPSHOT</gt.version>
+    <gt.version>21-SNAPSHOT</gt.version>
   </properties>
 
 </project>

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
   import simplejson as json
 
-class Feature_Test:
+class Feature_Test(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
@@ -197,7 +197,7 @@ class Feature_Test:
     assert u'1' in xp.findvalues('//gsf:x', doc) 
     assert u'1.1' in xp.findvalues('//gsf:y', doc) 
     assert u'one' in xp.findvalues('//gsf:z', doc) 
-    assert u'-125.0 50.0' in xp.findvalues('//gsf:geom/gml:Point/gml:pos', doc)
+    self.assertIn(u'-125 50', xp.findvalues('//gsf:geom/gml:Point/gml:pos', doc))
 
   def testWriteGML32(self):
     g = geom.Point(-125, 50)
@@ -211,5 +211,5 @@ class Feature_Test:
     assert u'1' in xp.findvalues('//gsf:x', doc) 
     assert u'1.1' in xp.findvalues('//gsf:y', doc) 
     assert u'one' in xp.findvalues('//gsf:z', doc) 
-    assert u'-125.0 50.0' in xp.findvalues('//gsf:geom/gml:Point/gml:pos', doc)
+    self.assertIn(u'-125 50', xp.findvalues('//gsf:geom/gml:Point/gml:pos', doc))
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -2,7 +2,7 @@ import unittest
 from .util import assertClose
 from geoscript import geom
 from geoscript.util import bytes
-from com.vividsolutions.jts.geom import Coordinate, GeometryFactory
+from org.locationtech.jts.geom import Coordinate, GeometryFactory
 
 class GeomTest(unittest.TestCase):
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -58,25 +58,25 @@ class GeomTest(unittest.TestCase):
 
   def testCircularString(self):
     cs = geom.CircularString([6.12, 10.0],[7.07, 7.07],[10.0, 0.0])
-    self.assertEqual('CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)', str(cs))
+    self.assertEqual('CIRCULARSTRING (6.12 10.0, 7.07 7.07, 10.0 0.0)', str(cs))
   
   def testCircularRing(self):
     cr = geom.CircularRing( [2.0, 1.0], [1.0, 2.0], [0.0, 1.0], [1.0, 0.0], [2.0, 1.0])
-    self.assertEqual('CIRCULARSTRING(2.0 1.0, 1.0 2.0, 0.0 1.0, 1.0 0.0, 2.0 1.0)', str(cr))
+    self.assertEqual('CIRCULARSTRING (2.0 1.0, 1.0 2.0, 0.0 1.0, 1.0 0.0, 2.0 1.0)', str(cr))
 
   def testCompoundCurve(self):
     cc = geom.CompoundCurve(
         geom.CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]),
         geom.LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0])
     )
-    self.assertEqual('COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))', str(cc))
+    self.assertEqual('COMPOUNDCURVE (CIRCULARSTRING (10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))', str(cc))
 
   def testCompoundRing(self):
     cc = geom.CompoundRing(
         geom.CircularString([10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]),
         geom.LineString([-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [10.0, 10.0])
     )
-    self.assertEqual('COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 10.0 10.0))', str(cc))
+    self.assertEqual('COMPOUNDCURVE (CIRCULARSTRING (10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 10.0 10.0))', str(cc))
 
   def testBounds(self):
     b = geom.Bounds(1.0, 2.0, 3.0, 4.0)


### PR DESCRIPTION
Updates required for Geoscript-py to work with the latest GeoServer/GeoTools.

- Removed the explicit dependencies listed in the Ant-run plugin in the pom. These were causing some version discrepancies when trying to run the build.
- Update GeoTools class/package names to match GeoTools 21 names.
- Update JTS package names.

I tested this with the Geoserver geoscript tests, but wasn't able to run the tests in the project. It looks like the website is down so I couldn't look at the developer guide.